### PR TITLE
feat(settings): add provider settings route (#109)

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -20,9 +20,10 @@ interface LayoutProps {
  *
  * @param props - The layout props
  * @param props.children - The main content to be rendered
+ * @param props.title - The page title (optional)
  * @returns The terminal-style page layout with navigation and content in a single bordered container
  */
-export function Layout({ children }: Omit<LayoutProps, 'title'>) {
+export function Layout({ children, title }: LayoutProps) {
   return (
     <RealtimeProvider>
       <div box-="square" shear-="top">

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -193,6 +193,9 @@ export function Navigation() {
         <a href="/stats">
           <span is-="badge">STATS</span>
         </a>
+        <a href="/settings">
+          <span is-="badge">SETTINGS</span>
+        </a>
       </span>
       <span>
         {combinedIsConnected && (

--- a/src/components/ProviderForm.tsx
+++ b/src/components/ProviderForm.tsx
@@ -1,0 +1,303 @@
+import React, { useState, useEffect } from 'react';
+
+/**
+ * Provider data interface
+ */
+interface Provider {
+  id: string;
+  name: string;
+  type: string;
+  apiKey: string;
+  baseUrl?: string;
+  models?: string[];
+  settings?: Record<string, unknown>;
+  isActive: boolean;
+  isDefault: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/**
+ * Form data interface
+ */
+interface FormData {
+  name: string;
+  type: string;
+  apiKey: string;
+  baseUrl: string;
+  models: string;
+  isActive: boolean;
+  isDefault: boolean;
+}
+
+/**
+ * Props for ProviderForm component
+ */
+interface ProviderFormProps {
+  provider?: Provider | null;
+  onSubmit: () => void;
+  onCancel: () => void;
+}
+
+/**
+ * Provider form component for creating and editing AI providers.
+ * Handles validation, submission, and error display.
+ */
+export function ProviderForm({ provider, onSubmit, onCancel }: ProviderFormProps) {
+  const [formData, setFormData] = useState<FormData>({
+    name: '',
+    type: 'openai',
+    apiKey: '',
+    baseUrl: '',
+    models: '',
+    isActive: true,
+    isDefault: false,
+  });
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Provider type options
+  const providerTypes = [
+    { value: 'openai', label: 'OpenAI' },
+    { value: 'anthropic', label: 'Anthropic' },
+    { value: 'groq', label: 'Groq' },
+  ];
+
+  // Populate form data when editing
+  useEffect(() => {
+    if (provider) {
+      setFormData({
+        name: provider.name,
+        type: provider.type,
+        apiKey: provider.apiKey,
+        baseUrl: provider.baseUrl || '',
+        models: Array.isArray(provider.models) ? provider.models.join(', ') : '',
+        isActive: provider.isActive,
+        isDefault: provider.isDefault,
+      });
+    }
+  }, [provider]);
+
+  /**
+   * Handle form field changes
+   */
+  const handleChange = (field: keyof FormData, value: string | boolean) => {
+    setFormData(prev => ({ ...prev, [field]: value }));
+    setError(null); // Clear error on input
+  };
+
+  /**
+   * Validate form data
+   */
+  const validateForm = (): string | null => {
+    if (!formData.name.trim()) {
+      return 'Provider name is required';
+    }
+    if (!formData.type) {
+      return 'Provider type is required';
+    }
+    if (!formData.apiKey.trim()) {
+      return 'API key is required';
+    }
+    if (formData.baseUrl && !isValidUrl(formData.baseUrl)) {
+      return 'Base URL must be a valid URL';
+    }
+    return null;
+  };
+
+  /**
+   * Check if string is a valid URL
+   */
+  const isValidUrl = (string: string): boolean => {
+    try {
+      new URL(string);
+      return true;
+    } catch {
+      return false;
+    }
+  };
+
+  /**
+   * Handle form submission
+   */
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    const validationError = validateForm();
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      // Prepare submission data
+      const submitData = {
+        name: formData.name.trim(),
+        type: formData.type,
+        apiKey: formData.apiKey.trim(),
+        baseUrl: formData.baseUrl.trim() || undefined,
+        models: formData.models.trim()
+          ? formData.models
+              .split(',')
+              .map(model => model.trim())
+              .filter(model => model)
+          : undefined,
+        isActive: formData.isActive,
+        isDefault: formData.isDefault,
+      };
+
+      const url = provider ? `/api/providers/${provider.id}` : '/api/providers';
+      const method = provider ? 'PUT' : 'POST';
+
+      const response = await fetch(url, {
+        method,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(submitData),
+      });
+
+      const result = await response.json();
+
+      if (result.success) {
+        onSubmit();
+      } else {
+        setError(result.error || 'Failed to save provider');
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Network error');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <div data-box="square" data-gap="2">
+        {error && (
+          <div data-box="square" variant-="red">
+            <strong>Error:</strong> {error}
+          </div>
+        )}
+
+        <div data-gap="1">
+          <label htmlFor="name">
+            <strong>Provider Name *</strong>
+          </label>
+          <input
+            id="name"
+            type="text"
+            className="wui-input"
+            value={formData.name}
+            onChange={e => handleChange('name', e.target.value)}
+            placeholder="e.g., OpenAI GPT-4"
+            required
+          />
+          <small>A unique display name for this provider</small>
+        </div>
+
+        <div data-gap="1">
+          <label htmlFor="type">
+            <strong>Provider Type *</strong>
+          </label>
+          <select
+            id="type"
+            className="wui-input"
+            value={formData.type}
+            onChange={e => handleChange('type', e.target.value)}
+            required
+          >
+            {providerTypes.map(type => (
+              <option key={type.value} value={type.value}>
+                {type.label}
+              </option>
+            ))}
+          </select>
+          <small>Select the AI provider service type</small>
+        </div>
+
+        <div data-gap="1">
+          <label htmlFor="apiKey">
+            <strong>API Key *</strong>
+          </label>
+          <input
+            id="apiKey"
+            type="password"
+            className="wui-input"
+            value={formData.apiKey}
+            onChange={e => handleChange('apiKey', e.target.value)}
+            placeholder="Enter your API key"
+            required
+          />
+          <small>Your authentication key for this provider</small>
+        </div>
+
+        <div data-gap="1">
+          <label htmlFor="baseUrl">
+            <strong>Base URL</strong>
+          </label>
+          <input
+            id="baseUrl"
+            type="url"
+            className="wui-input"
+            value={formData.baseUrl}
+            onChange={e => handleChange('baseUrl', e.target.value)}
+            placeholder="e.g., https://api.openai.com/v1"
+          />
+          <small>Optional custom API endpoint URL</small>
+        </div>
+
+        <div data-gap="1">
+          <label htmlFor="models">
+            <strong>Available Models</strong>
+          </label>
+          <input
+            id="models"
+            type="text"
+            className="wui-input"
+            value={formData.models}
+            onChange={e => handleChange('models', e.target.value)}
+            placeholder="e.g., gpt-4, gpt-3.5-turbo"
+          />
+          <small>Comma-separated list of available models</small>
+        </div>
+
+        <div data-gap="1">
+          <label>
+            <input
+              type="checkbox"
+              checked={formData.isActive}
+              onChange={e => handleChange('isActive', e.target.checked)}
+            />
+            <strong> Active</strong>
+          </label>
+          <small>Whether this provider is available for use</small>
+        </div>
+
+        <div data-gap="1">
+          <label>
+            <input
+              type="checkbox"
+              checked={formData.isDefault}
+              onChange={e => handleChange('isDefault', e.target.checked)}
+            />
+            <strong> Set as Default</strong>
+          </label>
+          <small>Make this the default provider for new requests</small>
+        </div>
+
+        <div data-align="end" data-gap="1">
+          <button type="button" onClick={onCancel} className="wui-button" disabled={loading}>
+            Cancel
+          </button>
+          <button type="submit" className="wui-button" disabled={loading}>
+            {loading ? 'Saving...' : provider ? 'Update Provider' : 'Create Provider'}
+          </button>
+        </div>
+      </div>
+    </form>
+  );
+}

--- a/src/components/ProviderList.tsx
+++ b/src/components/ProviderList.tsx
@@ -1,0 +1,145 @@
+import React from 'react';
+
+/**
+ * Provider data interface
+ */
+interface Provider {
+  id: string;
+  name: string;
+  type: string;
+  apiKey: string;
+  baseUrl?: string;
+  models?: string[];
+  settings?: Record<string, unknown>;
+  isActive: boolean;
+  isDefault: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/**
+ * Props for ProviderList component
+ */
+interface ProviderListProps {
+  providers: Provider[];
+  onEdit: (provider: Provider) => void;
+  onDelete: (id: string) => void;
+  onTest: (id: string) => void;
+  onSetDefault: (id: string) => void;
+}
+
+/**
+ * Provider list component displaying all configured AI providers.
+ * Provides actions for editing, deleting, testing, and setting default providers.
+ */
+export function ProviderList({
+  providers,
+  onEdit,
+  onDelete,
+  onTest,
+  onSetDefault,
+}: ProviderListProps) {
+  if (providers.length === 0) {
+    return (
+      <div data-box="square" data-align="center">
+        <p>No providers configured.</p>
+        <small>Add a provider to get started.</small>
+      </div>
+    );
+  }
+
+  return (
+    <div data-box="square">
+      <table className="wui-table">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Status</th>
+            <th>Default</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {providers.map(provider => (
+            <tr key={provider.id}>
+              <td>
+                <strong>{provider.name}</strong>
+                {provider.baseUrl && (
+                  <div>
+                    <small>{provider.baseUrl}</small>
+                  </div>
+                )}
+              </td>
+              <td>
+                <span is-="badge" variant-="blue">
+                  {provider.type.toUpperCase()}
+                </span>
+              </td>
+              <td>
+                <span is-="badge" variant-={provider.isActive ? 'green' : 'surface0'}>
+                  {provider.isActive ? 'ACTIVE' : 'INACTIVE'}
+                </span>
+              </td>
+              <td>
+                {provider.isDefault ? (
+                  <span is-="badge" variant-="yellow">
+                    DEFAULT
+                  </span>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={() => onSetDefault(provider.id)}
+                    className="wui-button"
+                    disabled={!provider.isActive}
+                  >
+                    Set Default
+                  </button>
+                )}
+              </td>
+              <td>
+                <div data-align="start" data-gap="1">
+                  <button
+                    type="button"
+                    onClick={() => onTest(provider.id)}
+                    className="wui-button"
+                    disabled={!provider.isActive}
+                    title="Test provider connectivity"
+                  >
+                    Test
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => onEdit(provider)}
+                    className="wui-button"
+                    title="Edit provider settings"
+                  >
+                    Edit
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => onDelete(provider.id)}
+                    className="wui-button"
+                    title="Delete provider"
+                    disabled={provider.isDefault}
+                  >
+                    Delete
+                  </button>
+                </div>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <div data-gap="1">
+        <p>
+          <strong>Total providers:</strong> {providers.length}
+        </p>
+        <small>
+          Active providers can be tested and set as default. The default provider cannot be deleted.
+        </small>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ProviderSettings.tsx
+++ b/src/components/ProviderSettings.tsx
@@ -1,0 +1,225 @@
+import React, { useState, useEffect } from 'react';
+import { ProviderList } from './ProviderList';
+import { ProviderForm } from './ProviderForm';
+
+/**
+ * Provider management interface data structures
+ */
+interface Provider {
+  id: string;
+  name: string;
+  type: string;
+  apiKey: string;
+  baseUrl?: string;
+  models?: string[];
+  settings?: Record<string, unknown>;
+  isActive: boolean;
+  isDefault: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface ProviderResponse {
+  success: boolean;
+  data?: {
+    providers: Provider[];
+    total: number;
+    limit: number;
+    offset: number;
+  };
+  error?: string;
+}
+
+interface SingleProviderResponse {
+  success: boolean;
+  data?: Provider;
+  error?: string;
+}
+
+/**
+ * Main provider settings management component.
+ * Provides interface for viewing, creating, editing, and deleting AI providers.
+ */
+export function ProviderSettings() {
+  const [providers, setProviders] = useState<Provider[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [editingProvider, setEditingProvider] = useState<Provider | null>(null);
+  const [showForm, setShowForm] = useState(false);
+
+  /**
+   * Fetch providers from API
+   */
+  const fetchProviders = async () => {
+    try {
+      setLoading(true);
+      const response = await fetch('/api/providers');
+      const result: ProviderResponse = await response.json();
+
+      if (result.success && result.data) {
+        setProviders(result.data.providers);
+        setError(null);
+      } else {
+        setError(result.error || 'Failed to fetch providers');
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Network error');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  /**
+   * Delete a provider
+   */
+  const handleDelete = async (id: string) => {
+    if (!confirm('Are you sure you want to delete this provider?')) {
+      return;
+    }
+
+    try {
+      const response = await fetch(`/api/providers/${id}`, {
+        method: 'DELETE',
+      });
+      const result = await response.json();
+
+      if (result.success) {
+        await fetchProviders(); // Refresh the list
+      } else {
+        setError(result.error || 'Failed to delete provider');
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Network error');
+    }
+  };
+
+  /**
+   * Test provider connectivity
+   */
+  const handleTest = async (id: string) => {
+    try {
+      const response = await fetch(`/api/providers/${id}/test`, {
+        method: 'POST',
+      });
+      const result = await response.json();
+
+      if (result.success && result.data.success) {
+        alert('Provider test successful!');
+      } else {
+        alert(`Provider test failed: ${result.data.error || 'Unknown error'}`);
+      }
+    } catch (err) {
+      alert(`Test failed: ${err instanceof Error ? err.message : 'Network error'}`);
+    }
+  };
+
+  /**
+   * Set provider as default
+   */
+  const handleSetDefault = async (id: string) => {
+    try {
+      const response = await fetch(`/api/providers/${id}/set-default`, {
+        method: 'POST',
+      });
+      const result = await response.json();
+
+      if (result.success) {
+        await fetchProviders(); // Refresh the list
+      } else {
+        setError(result.error || 'Failed to set default provider');
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Network error');
+    }
+  };
+
+  /**
+   * Handle form submission (create or update)
+   */
+  const handleFormSubmit = async () => {
+    await fetchProviders(); // Refresh the list
+    setShowForm(false);
+    setEditingProvider(null);
+  };
+
+  /**
+   * Start editing a provider
+   */
+  const handleEdit = (provider: Provider) => {
+    setEditingProvider(provider);
+    setShowForm(true);
+  };
+
+  /**
+   * Start creating a new provider
+   */
+  const handleCreate = () => {
+    setEditingProvider(null);
+    setShowForm(true);
+  };
+
+  /**
+   * Cancel form
+   */
+  const handleCancel = () => {
+    setShowForm(false);
+    setEditingProvider(null);
+  };
+
+  // Fetch providers on component mount
+  useEffect(() => {
+    fetchProviders();
+  }, []);
+
+  if (loading) {
+    return (
+      <div data-box="square" data-align="center">
+        <p>Loading providers...</p>
+      </div>
+    );
+  }
+
+  if (showForm) {
+    return (
+      <div data-gap="2">
+        <div data-align="space-between">
+          <h2>{editingProvider ? 'Edit Provider' : 'Create Provider'}</h2>
+          <button type="button" onClick={handleCancel} className="wui-button">
+            Back to List
+          </button>
+        </div>
+
+        <ProviderForm
+          provider={editingProvider}
+          onSubmit={handleFormSubmit}
+          onCancel={handleCancel}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div data-gap="2">
+      <div data-align="space-between">
+        <h2>AI Providers</h2>
+        <button type="button" onClick={handleCreate} className="wui-button">
+          Add Provider
+        </button>
+      </div>
+
+      {error && (
+        <div data-box="square" variant-="red">
+          <strong>Error:</strong> {error}
+        </div>
+      )}
+
+      <ProviderList
+        providers={providers}
+        onEdit={handleEdit}
+        onDelete={handleDelete}
+        onTest={handleTest}
+        onSetDefault={handleSetDefault}
+      />
+    </div>
+  );
+}

--- a/src/lib/services/provider-service.ts
+++ b/src/lib/services/provider-service.ts
@@ -1,0 +1,285 @@
+import { AiProvider as AiProviderModel } from '../db/models/AiProvider';
+import { ProviderManager } from '../ai/provider-manager';
+import {
+  createProviderSchema,
+  updateProviderSchema,
+  providerQuerySchema,
+} from '../validation/provider-schemas';
+
+/**
+ * Service for managing AI providers with database persistence.
+ * Extends ProviderManager to add CRUD operations for providers stored in the database.
+ */
+export class ProviderService {
+  /**
+   * Get all providers with optional filtering.
+   * Validates query parameters and returns paginated results.
+   */
+  static async getProviders(queryParams: unknown = {}): Promise<{
+    providers: AiProviderModel[];
+    total: number;
+    limit: number;
+    offset: number;
+  }> {
+    const params = providerQuerySchema.parse(queryParams);
+
+    const where: Record<string, unknown> = {};
+
+    if (params.type !== undefined) {
+      where.type = params.type;
+    }
+
+    if (params.isActive !== undefined) {
+      where.isActive = params.isActive;
+    }
+
+    if (params.isDefault !== undefined) {
+      where.isDefault = params.isDefault;
+    }
+
+    const { count, rows } = await AiProviderModel.findAndCountAll({
+      where,
+      limit: params.limit,
+      offset: params.offset,
+      order: [['createdAt', 'DESC']],
+    });
+
+    return {
+      providers: rows,
+      total: count,
+      limit: params.limit,
+      offset: params.offset,
+    };
+  }
+
+  /**
+   * Get a single provider by ID.
+   * Returns null if provider not found.
+   */
+  static async getProvider(id: string): Promise<AiProviderModel | null> {
+    return await AiProviderModel.findByPk(id);
+  }
+
+  /**
+   * Create a new provider.
+   * Validates input data and ensures only one default provider exists.
+   */
+  static async createProvider(data: unknown): Promise<AiProviderModel> {
+    const validatedData = createProviderSchema.parse(data);
+
+    // If this provider is being set as default, unset other defaults
+    if (validatedData.isDefault) {
+      await this.unsetDefaultProviders();
+    }
+
+    // Convert validated data to match Sequelize model expectations
+    const createData = {
+      name: validatedData.name,
+      type: validatedData.type,
+      apiKey: validatedData.apiKey,
+      baseUrl: validatedData.baseUrl || undefined,
+      models: validatedData.models ? { models: validatedData.models } : undefined,
+      settings: validatedData.settings || undefined,
+      isActive: validatedData.isActive,
+      isDefault: validatedData.isDefault,
+    };
+
+    return await AiProviderModel.create(createData as any);
+  }
+
+  /**
+   * Update an existing provider.
+   * Validates input data and handles default provider logic.
+   */
+  static async updateProvider(id: string, data: unknown): Promise<AiProviderModel | null> {
+    const validatedData = updateProviderSchema.parse(data);
+
+    const provider = await AiProviderModel.findByPk(id);
+    if (!provider) {
+      return null;
+    }
+
+    // If this provider is being set as default, unset other defaults
+    if (validatedData.isDefault) {
+      await this.unsetDefaultProviders();
+    }
+
+    // Convert validated data to match Sequelize model expectations
+    const updateData: Partial<{
+      name: string;
+      type: string;
+      apiKey: string;
+      baseUrl: string | undefined;
+      models: Record<string, unknown> | undefined;
+      settings: Record<string, unknown> | undefined;
+      isActive: boolean;
+      isDefault: boolean;
+    }> = {};
+
+    if (validatedData.name !== undefined) updateData.name = validatedData.name;
+    if (validatedData.type !== undefined) updateData.type = validatedData.type;
+    if (validatedData.apiKey !== undefined) updateData.apiKey = validatedData.apiKey;
+    if (validatedData.baseUrl !== undefined)
+      updateData.baseUrl = validatedData.baseUrl || undefined;
+    if (validatedData.models !== undefined)
+      updateData.models = validatedData.models ? { models: validatedData.models } : undefined;
+    if (validatedData.settings !== undefined) updateData.settings = validatedData.settings;
+    if (validatedData.isActive !== undefined) updateData.isActive = validatedData.isActive;
+    if (validatedData.isDefault !== undefined) updateData.isDefault = validatedData.isDefault;
+
+    await provider.update(updateData);
+    return provider;
+  }
+
+  /**
+   * Delete a provider by ID.
+   * Returns true if deleted, false if not found.
+   */
+  static async deleteProvider(id: string): Promise<boolean> {
+    const provider = await AiProviderModel.findByPk(id);
+    if (!provider) {
+      return false;
+    }
+
+    await provider.destroy();
+    return true;
+  }
+
+  /**
+   * Test provider connectivity.
+   * Uses ProviderManager to validate the provider configuration.
+   */
+  static async testProvider(id: string): Promise<{ success: boolean; error?: string }> {
+    const provider = await AiProviderModel.findByPk(id);
+    if (!provider) {
+      return { success: false, error: 'Provider not found' };
+    }
+
+    // Convert Sequelize model to plain object for ProviderManager
+    const providerData = {
+      id: provider.id,
+      name: provider.name,
+      type: provider.type,
+      apiKey: provider.apiKey,
+      baseUrl: provider.baseUrl || null,
+      models: provider.models,
+      settings: provider.settings,
+      isActive: provider.isActive,
+      isDefault: provider.isDefault,
+      createdAt: provider.createdAt,
+      updatedAt: provider.updatedAt,
+    };
+
+    return await ProviderManager.testProvider(providerData);
+  }
+
+  /**
+   * Get the default provider from database.
+   * Falls back to ProviderManager if no database provider is marked as default.
+   */
+  static async getDefaultProvider(): Promise<AiProviderModel | null> {
+    // First try to find a database provider marked as default
+    const defaultProvider = await AiProviderModel.findOne({
+      where: { isDefault: true, isActive: true },
+    });
+
+    if (defaultProvider) {
+      return defaultProvider;
+    }
+
+    // Fall back to environment-based provider from ProviderManager
+    const envProvider = await ProviderManager.getDefaultProvider();
+    if (!envProvider) {
+      return null;
+    }
+
+    // Create a database entry for the environment provider if it doesn't exist
+    const existingProvider = await AiProviderModel.findOne({
+      where: { name: envProvider.name, type: envProvider.type },
+    });
+
+    if (existingProvider) {
+      return existingProvider;
+    }
+
+    // Create new provider entry from environment
+    return await AiProviderModel.create({
+      name: envProvider.name,
+      type: envProvider.type,
+      apiKey: envProvider.apiKey,
+      baseUrl: envProvider.baseUrl || undefined,
+      models: envProvider.models as Record<string, unknown> | undefined,
+      settings: envProvider.settings as Record<string, unknown> | undefined,
+      isActive: envProvider.isActive,
+      isDefault: true,
+    } as any);
+  }
+
+  /**
+   * Set a provider as the default.
+   * Unsets all other providers as default first.
+   */
+  static async setDefaultProvider(id: string): Promise<AiProviderModel | null> {
+    const provider = await AiProviderModel.findByPk(id);
+    if (!provider) {
+      return null;
+    }
+
+    await this.unsetDefaultProviders();
+    await provider.update({ isDefault: true });
+    return provider;
+  }
+
+  /**
+   * Unset all providers as default.
+   * Helper method to ensure only one default provider exists.
+   */
+  private static async unsetDefaultProviders(): Promise<void> {
+    await AiProviderModel.update({ isDefault: false }, { where: { isDefault: true } });
+  }
+
+  /**
+   * Get active providers for use by ProviderManager.
+   * Returns database providers with fallback to environment providers.
+   */
+  static async getActiveProviders(): Promise<AiProviderModel[]> {
+    const dbProviders = await AiProviderModel.findAll({
+      where: { isActive: true },
+      order: [['createdAt', 'DESC']],
+    });
+
+    // If we have database providers, return them
+    if (dbProviders.length > 0) {
+      return dbProviders;
+    }
+
+    // Fall back to environment providers
+    const envProviders = await ProviderManager.getActiveProviders();
+
+    // Create database entries for environment providers
+    const createdProviders: AiProviderModel[] = [];
+    for (const envProvider of envProviders) {
+      const existing = await AiProviderModel.findOne({
+        where: { name: envProvider.name, type: envProvider.type },
+      });
+
+      if (!existing) {
+        const created = await AiProviderModel.create({
+          name: envProvider.name,
+          type: envProvider.type,
+          apiKey: envProvider.apiKey,
+          baseUrl: envProvider.baseUrl || undefined,
+          models: envProvider.models as Record<string, unknown> | undefined,
+          settings: envProvider.settings as Record<string, unknown> | undefined,
+          isActive: envProvider.isActive,
+          isDefault: envProvider.isDefault,
+        } as any);
+        createdProviders.push(created);
+      } else {
+        createdProviders.push(existing);
+      }
+    }
+
+    return createdProviders;
+  }
+}

--- a/src/lib/validation/provider-schemas.ts
+++ b/src/lib/validation/provider-schemas.ts
@@ -1,0 +1,60 @@
+import { z } from 'zod';
+
+/**
+ * Provider type enumeration for validation.
+ * Must match the AIProviderType from types.ts
+ */
+export const providerTypeSchema = z.enum(['openai', 'anthropic', 'groq']);
+
+/**
+ * Schema for provider creation data.
+ * Validates all required fields for creating a new AI provider.
+ */
+export const createProviderSchema = z.object({
+  name: z.string().min(1, 'Name is required').max(100, 'Name must be 100 characters or less'),
+  type: providerTypeSchema,
+  apiKey: z.string().min(1, 'API key is required'),
+  baseUrl: z.string().url('Base URL must be a valid URL').optional().or(z.literal('')),
+  models: z.array(z.string()).optional(),
+  settings: z.record(z.unknown()).optional(),
+  isActive: z.boolean().default(true),
+  isDefault: z.boolean().default(false),
+});
+
+/**
+ * Schema for provider update data.
+ * All fields optional except type validation when provided.
+ */
+export const updateProviderSchema = z.object({
+  name: z
+    .string()
+    .min(1, 'Name is required')
+    .max(100, 'Name must be 100 characters or less')
+    .optional(),
+  type: providerTypeSchema.optional(),
+  apiKey: z.string().min(1, 'API key is required').optional(),
+  baseUrl: z.string().url('Base URL must be a valid URL').optional().or(z.literal('')),
+  models: z.array(z.string()).optional(),
+  settings: z.record(z.unknown()).optional(),
+  isActive: z.boolean().optional(),
+  isDefault: z.boolean().optional(),
+});
+
+/**
+ * Schema for provider query parameters.
+ * Validates filtering and pagination options.
+ */
+export const providerQuerySchema = z.object({
+  type: providerTypeSchema.optional(),
+  isActive: z.coerce.boolean().optional(),
+  isDefault: z.coerce.boolean().optional(),
+  limit: z.coerce.number().min(1).max(100).default(50),
+  offset: z.coerce.number().min(0).default(0),
+});
+
+/**
+ * Type definitions for validated schemas
+ */
+export type CreateProviderData = z.infer<typeof createProviderSchema>;
+export type UpdateProviderData = z.infer<typeof updateProviderSchema>;
+export type ProviderQueryParams = z.infer<typeof providerQuerySchema>;

--- a/src/pages/api/providers.ts
+++ b/src/pages/api/providers.ts
@@ -1,0 +1,88 @@
+import type { APIRoute } from 'astro';
+import { ProviderService } from '../../lib/services/provider-service';
+
+/**
+ * API endpoint for provider management.
+ * Handles CRUD operations for AI providers.
+ */
+
+/**
+ * GET /api/providers
+ * Returns list of providers with optional filtering and pagination.
+ */
+export const GET: APIRoute = async ({ request }) => {
+  try {
+    const url = new globalThis.URL(request.url);
+    const queryParams = Object.fromEntries(url.searchParams);
+
+    const result = await ProviderService.getProviders(queryParams);
+
+    return new Response(
+      JSON.stringify({
+        success: true,
+        data: result,
+      }),
+      {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      }
+    );
+  } catch (error) {
+    console.error('Error fetching providers:', error);
+
+    return new Response(
+      JSON.stringify({
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      }),
+      {
+        status: 400,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      }
+    );
+  }
+};
+
+/**
+ * POST /api/providers
+ * Creates a new AI provider.
+ */
+export const POST: APIRoute = async ({ request }) => {
+  try {
+    const body = await request.json();
+
+    const provider = await ProviderService.createProvider(body);
+
+    return new Response(
+      JSON.stringify({
+        success: true,
+        data: provider,
+      }),
+      {
+        status: 201,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      }
+    );
+  } catch (error) {
+    console.error('Error creating provider:', error);
+
+    return new Response(
+      JSON.stringify({
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      }),
+      {
+        status: 400,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      }
+    );
+  }
+};

--- a/src/pages/api/providers/[id].ts
+++ b/src/pages/api/providers/[id].ts
@@ -1,0 +1,218 @@
+import type { APIRoute } from 'astro';
+import { ProviderService } from '../../../lib/services/provider-service';
+
+/**
+ * API endpoint for individual provider management.
+ * Handles GET, PUT, and DELETE operations for specific providers.
+ */
+
+/**
+ * GET /api/providers/:id
+ * Returns a single provider by ID.
+ */
+export const GET: APIRoute = async ({ params }) => {
+  try {
+    const { id } = params;
+
+    if (!id || typeof id !== 'string') {
+      return new Response(
+        JSON.stringify({
+          success: false,
+          error: 'Provider ID is required',
+        }),
+        {
+          status: 400,
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        }
+      );
+    }
+
+    const provider = await ProviderService.getProvider(id);
+
+    if (!provider) {
+      return new Response(
+        JSON.stringify({
+          success: false,
+          error: 'Provider not found',
+        }),
+        {
+          status: 404,
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        }
+      );
+    }
+
+    return new Response(
+      JSON.stringify({
+        success: true,
+        data: provider,
+      }),
+      {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      }
+    );
+  } catch (error) {
+    console.error('Error fetching provider:', error);
+
+    return new Response(
+      JSON.stringify({
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      }),
+      {
+        status: 500,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      }
+    );
+  }
+};
+
+/**
+ * PUT /api/providers/:id
+ * Updates a provider by ID.
+ */
+export const PUT: APIRoute = async ({ params, request }) => {
+  try {
+    const { id } = params;
+
+    if (!id || typeof id !== 'string') {
+      return new Response(
+        JSON.stringify({
+          success: false,
+          error: 'Provider ID is required',
+        }),
+        {
+          status: 400,
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        }
+      );
+    }
+
+    const body = await request.json();
+    const provider = await ProviderService.updateProvider(id, body);
+
+    if (!provider) {
+      return new Response(
+        JSON.stringify({
+          success: false,
+          error: 'Provider not found',
+        }),
+        {
+          status: 404,
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        }
+      );
+    }
+
+    return new Response(
+      JSON.stringify({
+        success: true,
+        data: provider,
+      }),
+      {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      }
+    );
+  } catch (error) {
+    console.error('Error updating provider:', error);
+
+    return new Response(
+      JSON.stringify({
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      }),
+      {
+        status: 400,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      }
+    );
+  }
+};
+
+/**
+ * DELETE /api/providers/:id
+ * Deletes a provider by ID.
+ */
+export const DELETE: APIRoute = async ({ params }) => {
+  try {
+    const { id } = params;
+
+    if (!id || typeof id !== 'string') {
+      return new Response(
+        JSON.stringify({
+          success: false,
+          error: 'Provider ID is required',
+        }),
+        {
+          status: 400,
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        }
+      );
+    }
+
+    const deleted = await ProviderService.deleteProvider(id);
+
+    if (!deleted) {
+      return new Response(
+        JSON.stringify({
+          success: false,
+          error: 'Provider not found',
+        }),
+        {
+          status: 404,
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        }
+      );
+    }
+
+    return new Response(
+      JSON.stringify({
+        success: true,
+        message: 'Provider deleted successfully',
+      }),
+      {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      }
+    );
+  } catch (error) {
+    console.error('Error deleting provider:', error);
+
+    return new Response(
+      JSON.stringify({
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      }),
+      {
+        status: 500,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      }
+    );
+  }
+};

--- a/src/pages/api/providers/[id]/set-default.ts
+++ b/src/pages/api/providers/[id]/set-default.ts
@@ -1,0 +1,78 @@
+import type { APIRoute } from 'astro';
+import { ProviderService } from '../../../../lib/services/provider-service';
+
+/**
+ * API endpoint for setting a provider as default.
+ * POST /api/providers/:id/set-default
+ */
+
+/**
+ * POST /api/providers/:id/set-default
+ * Sets a provider as the default provider.
+ */
+export const POST: APIRoute = async ({ params }) => {
+  try {
+    const { id } = params;
+
+    if (!id || typeof id !== 'string') {
+      return new Response(
+        JSON.stringify({
+          success: false,
+          error: 'Provider ID is required',
+        }),
+        {
+          status: 400,
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        }
+      );
+    }
+
+    const provider = await ProviderService.setDefaultProvider(id);
+
+    if (!provider) {
+      return new Response(
+        JSON.stringify({
+          success: false,
+          error: 'Provider not found',
+        }),
+        {
+          status: 404,
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        }
+      );
+    }
+
+    return new Response(
+      JSON.stringify({
+        success: true,
+        data: provider,
+        message: 'Provider set as default successfully',
+      }),
+      {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      }
+    );
+  } catch (error) {
+    console.error('Error setting default provider:', error);
+
+    return new Response(
+      JSON.stringify({
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      }),
+      {
+        status: 500,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      }
+    );
+  }
+};

--- a/src/pages/api/providers/[id]/test.ts
+++ b/src/pages/api/providers/[id]/test.ts
@@ -1,0 +1,62 @@
+import type { APIRoute } from 'astro';
+import { ProviderService } from '../../../../lib/services/provider-service';
+
+/**
+ * API endpoint for testing provider connectivity.
+ * POST /api/providers/:id/test
+ */
+
+/**
+ * POST /api/providers/:id/test
+ * Tests connectivity for a specific provider.
+ */
+export const POST: APIRoute = async ({ params }) => {
+  try {
+    const { id } = params;
+
+    if (!id || typeof id !== 'string') {
+      return new Response(
+        JSON.stringify({
+          success: false,
+          error: 'Provider ID is required',
+        }),
+        {
+          status: 400,
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        }
+      );
+    }
+
+    const testResult = await ProviderService.testProvider(id);
+
+    return new Response(
+      JSON.stringify({
+        success: true,
+        data: testResult,
+      }),
+      {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      }
+    );
+  } catch (error) {
+    console.error('Error testing provider:', error);
+
+    return new Response(
+      JSON.stringify({
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      }),
+      {
+        status: 500,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      }
+    );
+  }
+};

--- a/src/pages/settings.astro
+++ b/src/pages/settings.astro
@@ -1,0 +1,25 @@
+---
+import { Layout } from '../components/Layout.tsx';
+---
+
+<Layout title="Settings">
+  <main>
+    <div data-box="square" data-align="center">
+      <h1>Settings</h1>
+    </div>
+
+    <div data-gap="2">
+      <section data-box="square">
+        <h2>Provider Management</h2>
+        <p>Configure AI providers for the application.</p>
+        <a href="/settings/providers" class="wui-button">Manage Providers</a>
+      </section>
+
+      <section data-box="square">
+        <h2>System Configuration</h2>
+        <p>Additional system settings will be available here in the future.</p>
+        <small>Coming soon...</small>
+      </section>
+    </div>
+  </main>
+</Layout>

--- a/src/pages/settings/providers.astro
+++ b/src/pages/settings/providers.astro
@@ -1,0 +1,14 @@
+---
+import { Layout } from '../../components/Layout.tsx';
+import { ProviderSettings } from '../../components/ProviderSettings.tsx';
+---
+
+<Layout title="Provider Settings">
+  <main>
+    <div data-box="square" data-align="center">
+      <h1>Provider Settings</h1>
+    </div>
+
+    <ProviderSettings client:load />
+  </main>
+</Layout>


### PR DESCRIPTION
## Summary
- Implement provider settings interface at `/settings/provider`
- Add API endpoints for provider CRUD operations
- Create UI components for managing AI providers

## Changes
- Provider service layer with database persistence
- Validation schemas using Zod
- REST API endpoints at `/api/providers/*`
- Settings pages with WebTUI design
- Provider list and form components
- Navigation integration with SETTINGS badge

## Test Plan
- [ ] Navigate to `/settings` and verify redirect
- [ ] Navigate to `/settings/providers` and verify UI loads
- [ ] Create a new provider with valid credentials
- [ ] Edit an existing provider
- [ ] Test provider connectivity
- [ ] Set a provider as default
- [ ] Delete a non-default provider
- [ ] Verify form validation for required fields
- [ ] Check that only one default provider can exist

Closes #109