### PR TITLE
fix(ci): correct release-please workflow configuration

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -25,10 +25,8 @@ jobs:
       - uses: googleapis/release-please-action@v4
         id: release
         with:
+          token: ${{ secrets.GITHUB_TOKEN }}
           release-type: node
-          package-name: salacia
-          bump-minor-pre-major: ${{ github.event.inputs.release-type == 'major' }}
-          bump-patch-for-minor-pre-major: ${{ github.event.inputs.release-type == 'major' }}
           
       # Optional: Build and test before release
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Remove invalid action parameters from release-please
- Add explicit GITHUB_TOKEN for permissions
- Simplify configuration for node release type

## Context
The release-please workflow was failing with:
1. "GitHub Actions is not permitted to create or approve pull requests" 
2. Invalid input parameters warnings

## Test plan
- [ ] Workflow runs without parameter warnings
- [ ] Release PR can be created with proper permissions