### PR TITLE
fix(sse): prevent heartbeat crashes on closed streams

### DIFF
--- a/src/pages/api/sse/messages.ts
+++ b/src/pages/api/sse/messages.ts
@@ -144,8 +144,21 @@ export const GET: APIRoute = async ({ request }) => {
       heartbeatInterval = globalThis.setInterval(() => {
         if (!isConnected) return;
 
-        const heartbeat = createHeartbeatMessage();
-        controller.enqueue(new TextEncoder().encode(heartbeat));
+        try {
+          // Check if controller is closed before writing
+          if (!controller.desiredSize || controller.desiredSize <= 0) {
+            cleanup();
+            return;
+          }
+
+          const heartbeat = createHeartbeatMessage();
+          controller.enqueue(new TextEncoder().encode(heartbeat));
+        } catch (error) {
+          if (config.debugMode) {
+            console.error('Heartbeat error:', error);
+          }
+          cleanup();
+        }
       }, config.heartbeatInterval);
 
       // Set up connection timeout

--- a/src/pages/api/sse/stats.ts
+++ b/src/pages/api/sse/stats.ts
@@ -253,8 +253,21 @@ export const GET: APIRoute = async ({ request }) => {
       heartbeatInterval = globalThis.setInterval(() => {
         if (!isConnected) return;
 
-        const heartbeat = createHeartbeatMessage();
-        controller.enqueue(new TextEncoder().encode(heartbeat));
+        try {
+          // Check if controller is closed before writing
+          if (!controller.desiredSize || controller.desiredSize <= 0) {
+            cleanup();
+            return;
+          }
+
+          const heartbeat = createHeartbeatMessage();
+          controller.enqueue(new TextEncoder().encode(heartbeat));
+        } catch (error) {
+          if (config.debugMode) {
+            console.error('Stats heartbeat error:', error);
+          }
+          cleanup();
+        }
       }, config.heartbeatInterval);
 
       // Set up connection timeout


### PR DESCRIPTION
## Summary
- Add stream state validation before heartbeat writes
- Wrap heartbeat operations in try-catch blocks
- Call cleanup on stream closure to prevent leaks

## Test plan
- [x] Verify heartbeat operations handle closed streams
- [x] Confirm no crashes on client disconnect
- [x] Test cleanup called on stream errors