### PR TITLE
fix(navigation): display dynamic version from package.json

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { useRealtime } from '../context/realtime.js';
+import packageJson from '../../package.json';
 
 /** Flash duration for +N badge animation */
 const PLUS_FLASH_DURATION_MS = 280;
@@ -228,7 +229,7 @@ export function Navigation() {
           SALACIA
         </span>
         <span is-="badge" variant-="background1">
-          v0.0.1
+          v{packageJson.version}
         </span>
       </span>
     </nav>


### PR DESCRIPTION
## Summary
- Replace hardcoded v0.0.1 with dynamic version from package.json
- Navigation now shows actual project version (v1.0.3)

## Test plan
- [x] Verify version displays correctly in navigation
- [x] Confirm no TypeScript errors
- [x] Test dev server restart picks up changes